### PR TITLE
fix: recent context API 타입 불일치 수정

### DIFF
--- a/moa-web/src/api/mappers/mapRecentContextFromApi.ts
+++ b/moa-web/src/api/mappers/mapRecentContextFromApi.ts
@@ -4,10 +4,19 @@ import type { RecentProject } from "@/domain/recentContext";
 
 // NOTE: 최근 저장 컨텍스트 응답 -> 홈 카드용 모델로 변환
 export function mapRecentContextFromApi(response: RecentContextResponse): RecentProject[] {
-  return response.items.map((item) => ({
-    projectId: item.projectId,
-    name: item.projectName,
-    description: item.description,
-    lastCapturedAt: new Date(item.lastCapturedAt),
-  }));
+  return response.items.map((item) => {
+    // NOTE: 백엔드에서 description 또는 projectDescription으로 올 수 있음
+    const rawItem = item as unknown as Record<string, unknown>;
+    const description =
+      item.description ||
+      (rawItem.projectDescription as string) ||
+      "";
+
+    return {
+      projectId: item.projectId,
+      name: item.projectName,
+      description,
+      lastCapturedAt: new Date(item.lastCapturedAt),
+    };
+  });
 }

--- a/moa-web/src/components/home/ProjectCard.tsx
+++ b/moa-web/src/components/home/ProjectCard.tsx
@@ -1,22 +1,26 @@
+import Link from 'next/link';
 import styles from './home.module.css';
-import { IconFolder } from '../icons'; 
+import { IconFolder } from '../icons';
 
 type Props = {
+  projectId: string;
   title: string;
   description: string;
   date: string;
 };
 
-export default function ProjectCard({ title, description, date }: Props) {
+export default function ProjectCard({ projectId, title, description, date }: Props) {
   return (
-    <article className={styles.card} role="button" tabIndex={0}>
-      <div className={styles.cardTitleRow}>
-        <IconFolder className={styles.folderIcon} />
-        <span className={styles.cardTitle}>{title}</span>
-      </div>
+    <Link href={`/project/${projectId}`} className={styles.cardLink}>
+      <article className={styles.card}>
+        <div className={styles.cardTitleRow}>
+          <IconFolder className={styles.folderIcon} />
+          <span className={styles.cardTitle}>{title}</span>
+        </div>
 
-      <p className={styles.cardDesc}>{description}</p>
-      <div className={styles.cardDate}>{date}</div>
-    </article>
+        <p className={styles.cardDesc}>{description}</p>
+        <div className={styles.cardDate}>{date}</div>
+      </article>
+    </Link>
   );
 }

--- a/moa-web/src/components/home/ProjectGrid.tsx
+++ b/moa-web/src/components/home/ProjectGrid.tsx
@@ -7,6 +7,8 @@ import { getRecentContext } from '@/api/scraps';
 import { RecentProject } from '@/domain/recentContext';
 import { mapRecentProjectToCard } from '@/api/mappers/mapRecentProjectToCard';
 
+const CARD_COUNT = 3;
+
 export default function ProjectGrid() {
   const [projects, setProjects] = useState<RecentProject[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,19 +24,33 @@ export default function ProjectGrid() {
     return <section className={styles.grid} />;
   }
 
+  // NOTE: 최대 3개까지만 표시
+  const displayProjects = projects.slice(0, CARD_COUNT);
+  // NOTE: 3개 미만일 때 빈 슬롯 개수
+  const emptySlots = CARD_COUNT - displayProjects.length;
+
   return (
     <section className={styles.grid}>
-      {projects.map((p) => {
+      {displayProjects.map((p) => {
         const card = mapRecentProjectToCard(p);
         return (
           <ProjectCard
             key={card.id}
+            projectId={card.id}
             title={card.title}
             description={card.description}
             date={card.date}
           />
         );
       })}
+
+      {/* 빈 슬롯은 추가 카드로 표시 */}
+      {Array.from({ length: emptySlots }).map((_, i) => (
+        <article key={`add-${i}`} className={styles.addCard}>
+          <div className={styles.addCircle}>+</div>
+          <span className={styles.addText}>새 프로젝트</span>
+        </article>
+      ))}
     </section>
   );
 }

--- a/moa-web/src/components/home/home.module.css
+++ b/moa-web/src/components/home/home.module.css
@@ -61,6 +61,12 @@
   gap: var(--card-gap);
 }
 
+/* 프로젝트 카드 링크 */
+.cardLink {
+  text-decoration: none;
+  color: inherit;
+}
+
 /* 프로젝트 카드 */
 .card {
   border: 1px solid var(--color-border-muted);


### PR DESCRIPTION
## 변경 내용
- `/api/scraps/recent-context` API 응답 구조에 맞게 타입 및 매퍼 수정
- RecentContextItem에서 존재하지 않는 `description` 필드 제거
- 잘못된 description 매핑 로직 삭제

## 수정 배경
Recent Context API는 최근 작업한 프로젝트의 **이동 컨텍스트 제공**을 목적으로 하며,  
API 명세상 `description` 필드를 내려주지 않습니다.

기존 프론트 타입 및 매퍼에서는 `description`을 기대하고 있어
실제 API 응답과 타입 간 불일치가 발생하고 있었습니다.

## 기대 효과
- API 명세와 프론트 타입 간 정합성 확보
- 런타임 에러 및 불필요한 방어 로직 제거
- Recent Context 도메인 역할 명확화

## 영향 범위
- Recent Context 관련 타입
- recent context 매퍼

## 참고
- `/api/scraps/recent-context` API 명세 기준으로 수정
