### PR TITLE
feat: Stage Digest API 연결

### DIFF
--- a/moa-web/src/api/digests.ts
+++ b/moa-web/src/api/digests.ts
@@ -1,0 +1,29 @@
+// src/api/digests.ts
+import { request } from "@/api/http";
+import type { StageDigestResponse } from "@/api/types/digest";
+import { mapStageDigestFromApi } from "@/api/mappers/mapStageDigestFromApi";
+import type { StageDigest } from "@/domain/digest";
+
+export async function getStageDigest(
+  projectId: number,
+  stageName: string
+): Promise<StageDigest> {
+  const encodedStage = encodeURIComponent(stageName);
+  const res = await request<StageDigestResponse>(
+    `/api/projects/${projectId}/stages/${encodedStage}/digest`,
+    "GET"
+  );
+  return mapStageDigestFromApi(res);
+}
+
+export async function refreshStageDigest(
+  projectId: number,
+  stageName: string
+): Promise<StageDigest> {
+  const encodedStage = encodeURIComponent(stageName);
+  const res = await request<StageDigestResponse>(
+    `/api/projects/${projectId}/stages/${encodedStage}/digest:refresh`,
+    "POST"
+  );
+  return mapStageDigestFromApi(res);
+}

--- a/moa-web/src/api/mappers/mapStageDigestFromApi.ts
+++ b/moa-web/src/api/mappers/mapStageDigestFromApi.ts
@@ -1,0 +1,23 @@
+// src/api/mappers/mapStageDigestFromApi.ts
+
+import type { StageDigestResponse } from "@/api/types/digest";
+import type { StageDigest } from "@/domain/digest";
+import { mapStageNameToKey } from "@/api/mappers/mapStage";
+
+export function mapStageDigestFromApi(res: StageDigestResponse): StageDigest {
+  return {
+    projectId: res.project.projectId,
+    projectName: res.project.projectName,
+    stageKey: mapStageNameToKey(res.stage),
+    stageName: res.stage,
+    digest: res.digest ?? null,
+    meta: {
+      exists: res.meta.exists,
+      outdated: res.meta.outdated,
+      sourceLastCapturedAt: res.meta.sourceLastCapturedAt ?? null,
+      latestScrapCapturedAt: res.meta.latestScrapCapturedAt ?? null,
+      updatedAt: res.meta.updatedAt ?? null,
+      version: res.meta.version,
+    },
+  };
+}

--- a/moa-web/src/api/types/digest.ts
+++ b/moa-web/src/api/types/digest.ts
@@ -1,0 +1,20 @@
+// src/api/types/digest.ts
+
+export interface DigestMetaResponse {
+  exists: boolean;
+  outdated: boolean;
+  sourceLastCapturedAt: string | null;
+  latestScrapCapturedAt: string | null;
+  updatedAt: string | null;
+  version: number;
+}
+
+export interface StageDigestResponse {
+  project: {
+    projectId: number;
+    projectName: string;
+  };
+  stage: string;
+  digest: string | null;
+  meta: DigestMetaResponse;
+}

--- a/moa-web/src/app/project/[projectId]/page.tsx
+++ b/moa-web/src/app/project/[projectId]/page.tsx
@@ -11,10 +11,10 @@ import type { Project } from "@/domain/project";
 import type { Scrap } from "@/domain/scrap";
 import type { StageKey } from "@/domain/stage";
 import type { StageDigest } from "@/domain/digest";
+import { getStageDigest, refreshStageDigest } from "@/api/digests";
 
 import { useSidebarState } from "@/contexts/SidebarContext";
 import { stages } from "@/constants/stages";
-import { mockStageDigests } from "@/mocks/stageDigest";
 
 import StageDigestCard from "@/components/StageDigestCard";
 import StageScrapSidebar from "@/components/StageScrapSidebar";
@@ -46,6 +46,11 @@ export default function ProjectPage() {
 
   // NOTE: 선택된 stage
   const [selectedStage, setSelectedStage] = useState<StageKey>("PLAN");
+
+  // NOTE: 요약 데이터
+  const [stageDigests, setStageDigests] = useState<
+    Partial<Record<StageKey, StageDigest>>
+  >({});
 
   // NOTE: 요약 갱신 중 상태
   const [refreshingStages, setRefreshingStages] = useState<Set<StageKey>>(
@@ -113,29 +118,28 @@ export default function ProjectPage() {
     };
   }, [projectId]);
 
-  // NOTE: Mock에서 stage별 digest 가져오기
-  const stageDigests = useMemo(() => {
-    const digests: Record<StageKey, StageDigest> = {} as Record<
-      StageKey,
-      StageDigest
-    >;
+  // NOTE: 선택된 stage의 digest 가져오기
+  useEffect(() => {
+    let isMounted = true;
+    const stageName =
+      stages.find((s) => s.key === selectedStage)?.name ?? selectedStage;
 
-    stages.forEach((stage) => {
-      const mock = mockStageDigests[stage.key];
-      if (mock) {
-        digests[stage.key] = {
-          projectId: mock.project.projectId,
-          projectName: mock.project.projectName,
-          stageKey: stage.key,
-          stageName: stage.name,
-          digest: mock.digest,
-          meta: mock.meta,
-        };
-      }
-    });
+    getStageDigest(projectId, stageName)
+      .then((digest) => {
+        if (!isMounted) return;
+        setStageDigests((prev) => ({
+          ...prev,
+          [selectedStage]: digest,
+        }));
+      })
+      .catch(() => {
+        // NOTE: 요약 조회 실패는 전체 화면을 막지 않음
+      });
 
-    return digests;
-  }, []);
+    return () => {
+      isMounted = false;
+    };
+  }, [projectId, selectedStage]);
 
   // NOTE: 현재 선택된 stage의 스크랩 필터링
   const currentStageScraps = useMemo(() => {
@@ -148,15 +152,32 @@ export default function ProjectPage() {
   // NOTE: 요약 갱신 핸들러 (Mock - 실제로는 API 호출)
   const handleRefresh = (stageKey: StageKey) => {
     setRefreshingStages((prev) => new Set(prev).add(stageKey));
+    const stageName =
+      stages.find((s) => s.key === stageKey)?.name ?? stageKey;
 
-    // Mock: 2초 후 갱신 완료
-    setTimeout(() => {
-      setRefreshingStages((prev) => {
-        const next = new Set(prev);
-        next.delete(stageKey);
-        return next;
+    const logTimer = setInterval(() => {
+      console.log(`[digest] refresh in progress: ${stageKey}`);
+    }, 1000);
+
+    refreshStageDigest(projectId, stageName)
+      .then((digest) => {
+        setStageDigests((prev) => ({
+          ...prev,
+          [stageKey]: digest,
+        }));
+      })
+      .catch(() => {
+        // NOTE: 409 등 갱신 실패 시 기존 요약 유지
+      })
+      .finally(() => {
+        clearInterval(logTimer);
+        console.log(`[digest] refresh completed: ${stageKey}`);
+        setRefreshingStages((prev) => {
+          const next = new Set(prev);
+          next.delete(stageKey);
+          return next;
+        });
       });
-    }, 2000);
   };
 
   // NOTE: 에러 표시


### PR DESCRIPTION
### PR 타입
- [ ] Feat : 새로운 기능 추가

### 반영 브랜치
feat/digest -> develop

### 변경 사항
Stage Digest API 도입을 위해 mock 테스트 코드를 확인 및 정리, 실제 API 호출로 연결했습니다.

동작 방식
* 탭을 바꾸면 해당 stage의 digest를 GET으로 가져옵니다.
* refresh 버튼 누르면 POST로 재생성 요청 후 결과를 갱신합니다.

### 테스트 결과
요약 내용 정상 출력. (스크랩 한 개 추가해서 refresh할 때 15초 정도 걸림)
<img width="1574" height="820" alt="image" src="https://github.com/user-attachments/assets/faad1636-8ff3-4600-a7bd-f04382e46be9" />
